### PR TITLE
Prevent foreach-warning when raw value is null

### DIFF
--- a/contao/templates/mm_attr_tabletext.html5
+++ b/contao/templates/mm_attr_tabletext.html5
@@ -1,5 +1,5 @@
 <table class="tabletext<?php echo $this->additional_class; ?>">
-	<?php foreach ($this->raw as $k => $row) : ?><tr>
+	<?php foreach ((array) $this->raw as $k => $row) : ?><tr>
 		<?php foreach ($row as $kk =>$col): ?><td><?php echo $col['value']; ?></td><?php endforeach; ?>
 	</tr><?php endforeach;?>
 </table>

--- a/contao/templates/mm_attr_tabletext.text
+++ b/contao/templates/mm_attr_tabletext.text
@@ -1,5 +1,5 @@
 <?php 
-foreach ($this->raw as $k => $row)
+foreach ((array) $this->raw as $k => $row)
 {
 	foreach ($row as $kk => $col)
 	{

--- a/contao/templates/mm_attr_tabletext.xhtml
+++ b/contao/templates/mm_attr_tabletext.xhtml
@@ -1,5 +1,5 @@
 <table class="tabletext<?php echo $this->additional_class; ?>">
-	<?php foreach ($this->raw as $k => $row) : ?><tr>
+	<?php foreach ((array) $this->raw as $k => $row) : ?><tr>
 		<?php foreach ($row as $kk =>$col): ?><td><?php echo $col['value']; ?></td><?php endforeach; ?>
 	</tr><?php endforeach;?>
 </table>


### PR DESCRIPTION
A PHP warning (`Invalid argument supplied for foreach()`) might be thrown if `$this->raw` is `null`. This is the case, when no rows in `tl_metamodel_tabletext` exist for the particular item.

See MetaModels/core#1084.

I decided to fix it this way (via template), as I wanted to let `null` a valid value for `$this->raw` and don't force an array.